### PR TITLE
updated project to publish a zip artifact of the repository files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .project
 .settings
 .classpath
+**/target

--- a/FIX Standard/pom.xml
+++ b/FIX Standard/pom.xml
@@ -97,6 +97,24 @@
 					<classesDirectory>${project.build.directory}/doc</classesDirectory>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                    <id>create-distribution</id>
+                    <phase>package</phase>
+                        <goals>
+                          <goal>single</goal>
+                        </goals>
+                        <configuration>
+                          <descriptors>
+                            <descriptor>${project.basedir}/src/main/assembly/repository-assembly.xml</descriptor>
+                          </descriptors>
+                        </configuration>
+                      </execution>
+                    </executions>
+            </plugin>            
 		</plugins>
 	</build>
 </project>

--- a/FIX Standard/src/main/assembly/repository-assembly.xml
+++ b/FIX Standard/src/main/assembly/repository-assembly.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2
+      http://maven.apache.org/xsd/assembly-1.1.2.xsd"
+>
+  <id>repository</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>  
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}</directory>
+      <includes>
+      	<include>FixRepository*.xml</include>
+      </includes>
+      <outputDirectory></outputDirectory>
+      <lineEnding>unix</lineEnding>
+      <filtered>false</filtered>
+    </fileSet>
+  </fileSets>
+  <dependencySets>
+  </dependencySets>
+</assembly>


### PR DESCRIPTION
I propose that the orchestrations project should publish a zip artifact containing the repository files. 
This artifact can then be unpacked for use in dependent but separate projects.  This pull request uses the maven-assembly-plugin to zip and publish the files.