### PR TITLE
Publish orchestrations as zip

### DIFF
--- a/FIX Standard/pom.xml
+++ b/FIX Standard/pom.xml
@@ -95,6 +95,24 @@
           </execution>
         </executions>
       </plugin>
+       <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                    <id>create-distribution</id>
+                    <phase>package</phase>
+                        <goals>
+                          <goal>single</goal>
+                        </goals>
+                        <configuration>
+                          <descriptors>
+                            <descriptor>${project.basedir}/src/main/assembly/repository-assembly.xml</descriptor>
+                          </descriptors>
+                        </configuration>
+                      </execution>
+                    </executions>
+            </plugin>       
 		</plugins>
 	</build>
 </project>

--- a/FIX Standard/pom.xml
+++ b/FIX Standard/pom.xml
@@ -95,7 +95,7 @@
           </execution>
         </executions>
       </plugin>
-       <plugin>
+       		<plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Re-instate the assembly plugin that creates the zip file of orchestrations.