### PR TITLE
Ep 294   fix 4.2 correction for ref msg type(372)

### DIFF
--- a/FIX Standard/OrchestraFIX42.xml
+++ b/FIX Standard/OrchestraFIX42.xml
@@ -7647,7 +7647,7 @@
       </fixr:documentation>
 			</fixr:annotation>
 		</fixr:field>
-		<fixr:field id="372" name="RefMsgType" type="String" added="FIX.4.2">
+		<fixr:field id="372" name="RefMsgType" type="MsgTypeCodeSet" added="FIX.4.2">
 			<fixr:annotation>
 				<fixr:documentation purpose="SYNOPSIS">
          The MsgType of the FIX message being referenced.

--- a/FIX Standard/OrchestraFIX44.xml
+++ b/FIX Standard/OrchestraFIX44.xml
@@ -1922,6 +1922,30 @@
       </fixr:documentation>
 				</fixr:annotation>
 			</fixr:code>
+			<fixr:code name="Preliminary" id="71004" value="3" sort="4" added="FIX.4.1">
+		<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+						Preliminary (without MiscFees and NetMoney) (Removed/Replaced)</fixr:documentation>
+		</fixr:annotation>
+</fixr:code>
+<fixr:code name="Calculated" id="71005" value="4" sort="5" added="FIX.4.1">
+		<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+						Calculated (includes MiscFees and NetMoney) (Removed/Replaced)</fixr:documentation>
+		</fixr:annotation>
+</fixr:code>
+<fixr:code name="CalculatedWithoutPreliminary" id="71006" value="5" sort="6" added="FIX.4.2">
+		<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+						Calculated without Preliminary (sent unsolicited by broker, includes MiscFees and NetMoney) (Removed/Replaced)</fixr:documentation>
+		</fixr:annotation>
+</fixr:code>
+<fixr:code name="Reversal" id="71007" value="6" sort="7" added="FIX.4.4" addedEP="5">
+		<fixr:annotation>
+				<fixr:documentation purpose="SYNOPSIS">
+						Reversal</fixr:documentation>
+		</fixr:annotation>
+</fixr:code>
 			<fixr:annotation>
 				<fixr:documentation purpose="SYNOPSIS">
          Identifies allocation transaction type

--- a/FIX Standard/OrchestraFIX44.xml
+++ b/FIX Standard/OrchestraFIX44.xml
@@ -1922,30 +1922,6 @@
       </fixr:documentation>
 				</fixr:annotation>
 			</fixr:code>
-			<fixr:code name="Preliminary" id="71004" value="3" sort="4" added="FIX.4.1">
-		<fixr:annotation>
-				<fixr:documentation purpose="SYNOPSIS">
-						Preliminary (without MiscFees and NetMoney) (Removed/Replaced)</fixr:documentation>
-		</fixr:annotation>
-</fixr:code>
-<fixr:code name="Calculated" id="71005" value="4" sort="5" added="FIX.4.1">
-		<fixr:annotation>
-				<fixr:documentation purpose="SYNOPSIS">
-						Calculated (includes MiscFees and NetMoney) (Removed/Replaced)</fixr:documentation>
-		</fixr:annotation>
-</fixr:code>
-<fixr:code name="CalculatedWithoutPreliminary" id="71006" value="5" sort="6" added="FIX.4.2">
-		<fixr:annotation>
-				<fixr:documentation purpose="SYNOPSIS">
-						Calculated without Preliminary (sent unsolicited by broker, includes MiscFees and NetMoney) (Removed/Replaced)</fixr:documentation>
-		</fixr:annotation>
-</fixr:code>
-<fixr:code name="Reversal" id="71007" value="6" sort="7" added="FIX.4.4" addedEP="5">
-		<fixr:annotation>
-				<fixr:documentation purpose="SYNOPSIS">
-						Reversal</fixr:documentation>
-		</fixr:annotation>
-</fixr:code>
 			<fixr:annotation>
 				<fixr:documentation purpose="SYNOPSIS">
          Identifies allocation transaction type

--- a/FIX Standard/OrchestraFIX44.xml
+++ b/FIX Standard/OrchestraFIX44.xml
@@ -10035,12 +10035,30 @@
       </fixr:documentation>
 				</fixr:annotation>
 			</fixr:code>
+			<fixr:code name="SellsideCalculatedUsingPreliminary" id="626003" value="3" sort="3" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
+					<fixr:annotation>
+							<fixr:documentation purpose="SYNOPSIS">
+									Sellside calculated using preliminary (includes MiscFees and NetMoney) (Replaced)</fixr:documentation>
+					</fixr:annotation>
+			</fixr:code>
+			<fixr:code name="SellsideCalculatedWithoutPreliminary" id="626004" value="4" sort="4" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
+					<fixr:annotation>
+							<fixr:documentation purpose="SYNOPSIS">
+									Sellside calculatedd without preliminary (sent unsolicited by sellside, includes MiscFees and NetMoney) (Replaced)</fixr:documentation>
+					</fixr:annotation>
+			</fixr:code>
 			<fixr:code name="ReadyToBook" id="626003" value="5" added="FIX.4.3">
 				<fixr:annotation>
 					<fixr:documentation purpose="SYNOPSIS">
          Ready-To-Book
       </fixr:documentation>
 				</fixr:annotation>
+			</fixr:code>
+			<fixr:code name="BuysideReadyToBook" id="626006" value="6" sort="6" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
+					<fixr:annotation>
+							<fixr:documentation purpose="SYNOPSIS">
+									Buyside Ready-To-Book - combined set of orders (replaced)</fixr:documentation>
+					</fixr:annotation>
 			</fixr:code>
 			<fixr:code name="WarehouseInstruction" id="626004" value="7" added="FIX.4.4">
 				<fixr:annotation>

--- a/FIX Standard/OrchestraFIX44.xml
+++ b/FIX Standard/OrchestraFIX44.xml
@@ -10054,12 +10054,6 @@
       </fixr:documentation>
 				</fixr:annotation>
 			</fixr:code>
-			<fixr:code name="BuysideReadyToBook" id="626006" value="6" sort="6" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
-					<fixr:annotation>
-							<fixr:documentation purpose="SYNOPSIS">
-									Buyside Ready-To-Book - combined set of orders (replaced)</fixr:documentation>
-					</fixr:annotation>
-			</fixr:code>
 			<fixr:code name="WarehouseInstruction" id="626004" value="7" added="FIX.4.4">
 				<fixr:annotation>
 					<fixr:documentation purpose="SYNOPSIS">

--- a/FIX Standard/OrchestraFIX44.xml
+++ b/FIX Standard/OrchestraFIX44.xml
@@ -10030,6 +10030,12 @@
       </fixr:documentation>
 				</fixr:annotation>
 			</fixr:code>
+			<fixr:code name="BuysideReadyToBook" id="626006" value="6" sort="6" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
+					<fixr:annotation>
+							<fixr:documentation purpose="SYNOPSIS">
+									Buyside Ready-To-Book - combined set of orders (replaced)</fixr:documentation>
+					</fixr:annotation>
+			</fixr:code>
 			<fixr:code name="WarehouseInstruction" id="626004" value="7" added="FIX.4.4">
 				<fixr:annotation>
 					<fixr:documentation purpose="SYNOPSIS">

--- a/FIX Standard/OrchestraFIX44.xml
+++ b/FIX Standard/OrchestraFIX44.xml
@@ -10011,30 +10011,12 @@
       </fixr:documentation>
 				</fixr:annotation>
 			</fixr:code>
-			<fixr:code name="SellsideCalculatedUsingPreliminary" id="626003" value="3" sort="3" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
-					<fixr:annotation>
-							<fixr:documentation purpose="SYNOPSIS">
-									Sellside calculated using preliminary (includes MiscFees and NetMoney) (Replaced)</fixr:documentation>
-					</fixr:annotation>
-			</fixr:code>
-			<fixr:code name="SellsideCalculatedWithoutPreliminary" id="626004" value="4" sort="4" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
-					<fixr:annotation>
-							<fixr:documentation purpose="SYNOPSIS">
-									Sellside calculatedd without preliminary (sent unsolicited by sellside, includes MiscFees and NetMoney) (Replaced)</fixr:documentation>
-					</fixr:annotation>
-			</fixr:code>
 			<fixr:code name="ReadyToBook" id="626003" value="5" added="FIX.4.3">
 				<fixr:annotation>
 					<fixr:documentation purpose="SYNOPSIS">
          Ready-To-Book
       </fixr:documentation>
 				</fixr:annotation>
-			</fixr:code>
-			<fixr:code name="BuysideReadyToBook" id="626006" value="6" sort="6" added="FIX.4.3" updated="FIX.5.0SP2" updatedEP="118">
-					<fixr:annotation>
-							<fixr:documentation purpose="SYNOPSIS">
-									Buyside Ready-To-Book - combined set of orders (replaced)</fixr:documentation>
-					</fixr:annotation>
 			</fixr:code>
 			<fixr:code name="WarehouseInstruction" id="626004" value="7" added="FIX.4.4">
 				<fixr:annotation>


### PR DESCRIPTION
Field RefMsgType(372) defines type=“String” instead of “MsgTypeCodeSet”
This correction is for FIX 4.2