### PR TITLE
#45 Update pom.xml to use new name of renamed file

### DIFF
--- a/FIX Standard/pom.xml
+++ b/FIX Standard/pom.xml
@@ -111,7 +111,7 @@
 						<configuration>
 							<mainClass>io.fixprotocol.orchestra.docgen.DocGenerator</mainClass>
 							<arguments>
-								<argument>${project.basedir}/fixsessionlayer.xml</argument>
+								<argument>${project.basedir}/FIXTSession.xml</argument>
 								<argument>${doc.directory}/fixtsession</argument>
 							</arguments>
 						</configuration>


### PR DESCRIPTION
This change will make the project buildable with **JDK 8** (and presumably below).
Otherwise builds error will be thrown since `fixsession.xml` has been [renamed](https://github.com/FIXTradingCommunity/orchestrations/commit/7de46b51ff355c5a25510db0ead80c63c18a3f78) to `FIXTSession.xml`, but corresponding changes have not been made in the `pom.xml`.

<details>

<summary>Maven Errors</summary>

```
[INFO] --- exec-maven-plugin:1.6.0:java (fixtsession) @ fix-standard ---
[WARNING] 
java.io.FileNotFoundException: /home/---/---/---/---/orchestrations/FIX Standard/fixsessionlayer.xml (No such file or directory)
    at java.io.FileInputStream.open0 (Native Method)
    at java.io.FileInputStream.open (FileInputStream.java:195)
    at java.io.FileInputStream.<init> (FileInputStream.java:138)
    at java.io.FileInputStream.<init> (FileInputStream.java:93)
    at io.fixprotocol.orchestra.docgen.DocGenerator.main (DocGenerator.java:121)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.mojo.exec.ExecJavaMojo$1.run (ExecJavaMojo.java:282)
    at java.lang.Thread.run (Thread.java:750)
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

</details>

**Newer JDKs will still produce build errors** as `jaxb` has been [moved out](https://www.jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/) of the JDK since Java 9. Created issue #46 for that.