### PR TITLE
#46: Make project buildable with JDK 9 and later

### DIFF
--- a/FIX Standard/pom.xml
+++ b/FIX Standard/pom.xml
@@ -24,6 +24,27 @@
 			<artifactId>orchestra2doc</artifactId>
 			<version>${orchestra.version}</version>
 		</dependency>
+		<dependency>
+			<!-- Marked as optional in io.fixprotocol.orchestra:repository-util:1.6.10 -->
+			<!-- Used here to make build compatible with both JDK 8 and JDK 8+ -->
+			<groupId>javax.xml.bind</groupId>
+		        <artifactId>jaxb-api</artifactId>
+	                <version>2.3.1</version>
+                </dependency>
+		<dependency>
+                        <!-- Marked as optional in io.fixprotocol.orchestra:repository-util:1.6.10 -->
+			<!-- Used here to make build compatible with both JDK 8 and JDK 8+ -->
+			<groupId>com.sun.xml.bind</groupId>
+		        <artifactId>jaxb-core</artifactId>
+		        <version>2.3.0.1</version>
+                </dependency>
+		<dependency>
+			<!-- Marked as optional in io.fixprotocol.orchestra:repository-util:1.6.10 -->
+			<!-- Used here to make build compatible with both JDK 8 and JDK 8+ -->
+			<groupId>com.sun.xml.bind</groupId>
+		        <artifactId>jaxb-impl</artifactId>
+		        <version>2.3.2</version>
+                </dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/FIX Standard/pom.xml
+++ b/FIX Standard/pom.xml
@@ -26,21 +26,21 @@
 		</dependency>
 		<dependency>
 			<!-- Marked as optional in io.fixprotocol.orchestra:repository-util:1.6.10 -->
-			<!-- Used here to make build compatible with both JDK 8 and JDK 8+ -->
+			<!-- Used here to make build compatible with JDK 9 and later -->
 			<groupId>javax.xml.bind</groupId>
 		        <artifactId>jaxb-api</artifactId>
 	                <version>2.3.1</version>
                 </dependency>
 		<dependency>
                         <!-- Marked as optional in io.fixprotocol.orchestra:repository-util:1.6.10 -->
-			<!-- Used here to make build compatible with both JDK 8 and JDK 8+ -->
+			<!-- Used here to make build compatible with JDK 9 and later -->
 			<groupId>com.sun.xml.bind</groupId>
 		        <artifactId>jaxb-core</artifactId>
 		        <version>2.3.0.1</version>
                 </dependency>
 		<dependency>
 			<!-- Marked as optional in io.fixprotocol.orchestra:repository-util:1.6.10 -->
-			<!-- Used here to make build compatible with both JDK 8 and JDK 8+ -->
+			<!-- Used here to make build compatible with JDK 9 and later -->
 			<groupId>com.sun.xml.bind</groupId>
 		        <artifactId>jaxb-impl</artifactId>
 		        <version>2.3.2</version>


### PR DESCRIPTION
External `jaxb` dependencies needed for builds with JDK 9 and later are defined in` io.fixprotocol.orchestra:repository-util:1.6.10`, but marked as optional.

Defining them here will make the project buildable with both JDK 8 (and presumably earlier) and JDK 9 and above.

Tested build with JDK 8 and 21.